### PR TITLE
Use literal supabase env lookups

### DIFF
--- a/src/lib/supabaseEnv.ts
+++ b/src/lib/supabaseEnv.ts
@@ -1,16 +1,16 @@
-const URL_VAR = "NEXT_PUBLIC_SUPABASE_URL" as const;
-const KEY_VAR = "NEXT_PUBLIC_SUPABASE_ANON_KEY" as const;
-
 type EnvVars = {
     url: string;
     anonKey: string;
 };
 
 export function getSupabaseEnv(): EnvVars {
-    const url = process.env[URL_VAR];
-    const anonKey = process.env[KEY_VAR];
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-    const missing = [!url && URL_VAR, !anonKey && KEY_VAR].filter(Boolean) as string[];
+    const missing = [
+        !url && "NEXT_PUBLIC_SUPABASE_URL",
+        !anonKey && "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+    ].filter(Boolean) as string[];
 
     if (missing.length > 0) {
         throw new Error(`Missing Supabase environment variables: ${missing.join(", ")}`);


### PR DESCRIPTION
## Summary
- access Supabase environment variables via literal process.env properties so Next.js can inline them
- keep the existing missing-variable guard for runtime validation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd1b70937c832198ab8dd6de826576