### PR TITLE
Fix Supabase session lookup for votes

### DIFF
--- a/src/lib/supabaseRoute.ts
+++ b/src/lib/supabaseRoute.ts
@@ -1,87 +1,48 @@
 import { cookies } from "next/headers";
-import { createClient, type Session } from "@supabase/supabase-js";
-import { parseSupabaseCookie } from "@supabase/auth-helpers-shared";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import type { Session, SupabaseClient } from "@supabase/supabase-js";
 
 import { getSupabaseEnv } from "./supabaseEnv";
 
-type CookieStore = Awaited<ReturnType<typeof cookies>>;
-
 export type SupabaseRouteResult = {
-    supabase: ReturnType<typeof createClient>;
-    session: Partial<Session> | null;
+    supabase: SupabaseClient;
+    session: Session | null;
 };
-
-function extractSupabaseSession(cookieStore: CookieStore): Partial<Session> | null {
-    const authCookies = cookieStore
-        .getAll()
-        .filter((cookie) => cookie.name.includes("-auth-token"));
-
-    if (authCookies.length === 0) {
-        return null;
-    }
-
-    const grouped = new Map<
-        string,
-        {
-            base?: string;
-            chunks: { index: number; value: string }[];
-        }
-    >();
-
-    for (const { name, value } of authCookies) {
-        const [prefix, chunkSuffix] = name.split(".");
-        const bucket = grouped.get(prefix) ?? { chunks: [] };
-
-        if (chunkSuffix === undefined) {
-            bucket.base = value;
-        } else {
-            const index = Number.parseInt(chunkSuffix, 10);
-            if (!Number.isNaN(index)) {
-                bucket.chunks.push({ index, value });
-            }
-        }
-
-        grouped.set(prefix, bucket);
-    }
-
-    for (const { base, chunks } of grouped.values()) {
-        let serialized = base ?? null;
-
-        if (!serialized && chunks.length > 0) {
-            chunks.sort((a, b) => a.index - b.index);
-            serialized = chunks.map((chunk) => chunk.value).join("");
-        }
-
-        if (!serialized) {
-            continue;
-        }
-
-        const session = parseSupabaseCookie(serialized);
-
-        if (session?.access_token) {
-            return session;
-        }
-    }
-
-    return null;
-}
 
 export async function supabaseRoute(): Promise<SupabaseRouteResult> {
     const { url, anonKey } = getSupabaseEnv();
     const cookieStore = await cookies();
-    const session = extractSupabaseSession(cookieStore);
+    const allCookies = cookieStore.getAll();
+    const supabaseAuthCookies = allCookies
+        .map((cookie) => cookie.name)
+        .filter((name) => name.includes("sb-"));
 
-    const supabase = createClient(url, anonKey, {
-        auth: {
-            autoRefreshToken: false,
-            persistSession: false,
-        },
-        global: {
-            headers: session?.access_token
-                ? { Authorization: `Bearer ${session.access_token}` }
-                : undefined,
-        },
+    console.debug("[supabaseRoute] cookies available", {
+        total: allCookies.length,
+        supabaseAuthCookies,
     });
 
-    return { supabase, session };
+    const supabase = createRouteHandlerClient(
+        { cookies: () => cookieStore },
+        {
+            supabaseUrl: url,
+            supabaseKey: anonKey,
+        }
+    );
+
+    const {
+        data: { session },
+        error,
+    } = await supabase.auth.getSession();
+
+    console.debug("[supabaseRoute] session resolved", {
+        hasSession: !!session,
+        hasAccessToken: !!session?.access_token,
+        expiresAt: session?.expires_at ?? null,
+        hasUser: !!session?.user,
+        hasError: !!error,
+        errorMessage: error?.message,
+    });
+
+    return { supabase, session: session ?? null };
 }

--- a/test/api/votes.route.test.ts
+++ b/test/api/votes.route.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DELETE, GET, POST } from "@/app/api/votes/route";
+import { supabaseRoute } from "@/lib/supabaseRoute";
+
+vi.mock("@/lib/supabaseRoute", () => ({
+    supabaseRoute: vi.fn(),
+}));
+
+type SupabaseMock = {
+    auth: {
+        getUser: ReturnType<typeof vi.fn>;
+    };
+    from: ReturnType<typeof vi.fn>;
+};
+
+const mockedSupabaseRoute = supabaseRoute as unknown as ReturnType<typeof vi.fn>;
+
+function futureTimestamp() {
+    return Math.floor(Date.now() / 1000) + 60;
+}
+
+function createFilterChain(result: unknown) {
+    const final = () => Promise.resolve(result);
+    const chain: any = {
+        eq: vi.fn(() => chain),
+        limit: vi.fn(() => final()),
+        maybeSingle: vi.fn(() => final()),
+        then: (resolve: (value: unknown) => void, reject?: (reason: unknown) => void) =>
+            final().then(resolve, reject),
+    };
+
+    return chain;
+}
+
+function createSelectBuilder(result: unknown) {
+    const chain = createFilterChain(result);
+    return {
+        select: vi.fn(() => chain),
+    } as const;
+}
+
+function createInsertBuilder(result: unknown) {
+    return {
+        insert: vi.fn(() => Promise.resolve(result)),
+    } as const;
+}
+
+function createDeleteBuilder(result: unknown) {
+    const chain = createFilterChain(result);
+    return {
+        delete: vi.fn(() => chain),
+    } as const;
+}
+
+function createSupabaseMock(steps: Array<Record<string, unknown>>): SupabaseMock {
+    const queue = [...steps];
+
+    return {
+        auth: {
+            getUser: vi.fn(),
+        },
+        from: vi.fn(() => {
+            const next = queue.shift();
+
+            if (!next) {
+                throw new Error("Unexpected call to from()");
+            }
+
+            return next;
+        }),
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("/api/votes", () => {
+    it("allows a user fetched from Supabase to vote", async () => {
+        const supabase = createSupabaseMock([
+            createSelectBuilder({ data: null, error: null }),
+            createInsertBuilder({ error: null }),
+            createSelectBuilder({ count: 3, error: null }),
+        ]);
+
+        supabase.auth.getUser.mockResolvedValue({
+            data: { user: { id: "user-123" } },
+            error: null,
+        });
+
+        mockedSupabaseRoute.mockResolvedValue({
+            supabase,
+            session: { access_token: "token", expires_at: futureTimestamp() },
+        });
+
+        const request = new Request("http://localhost/api/votes", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ productId: "product-1" }),
+        });
+
+        const response = await POST(request);
+        const payload = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(payload).toEqual({
+            message: "Ton vote a bien été pris en compte !",
+            votes: 3,
+        });
+        expect(supabase.auth.getUser).toHaveBeenCalledWith("token");
+    });
+
+    it("returns 401 when the user is not authenticated", async () => {
+        const supabase = createSupabaseMock([]);
+
+        mockedSupabaseRoute.mockResolvedValue({ supabase, session: null });
+
+        const request = new Request("http://localhost/api/votes", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ productId: "product-1" }),
+        });
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(401);
+        expect(supabase.from).not.toHaveBeenCalled();
+    });
+
+    it("reports when the authenticated user already voted", async () => {
+        const supabase = createSupabaseMock([
+            createSelectBuilder({ data: { id: "vote-1" }, error: null }),
+        ]);
+
+        mockedSupabaseRoute.mockResolvedValue({
+            supabase,
+            session: {
+                access_token: "token",
+                expires_at: futureTimestamp(),
+                user: { id: "user-123" } as any,
+            },
+        });
+
+        const request = new Request("http://localhost/api/votes", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ productId: "product-1" }),
+        });
+
+        const response = await POST(request);
+        const payload = await response.json();
+
+        expect(response.status).toBe(409);
+        expect(payload.message).toContain("déjà liké");
+    });
+
+    it("returns the vote status for an authenticated user", async () => {
+        const supabase = createSupabaseMock([
+            createSelectBuilder({ count: 5, error: null }),
+            createSelectBuilder({ data: [{ id: "vote-1" }], error: null }),
+        ]);
+
+        mockedSupabaseRoute.mockResolvedValue({
+            supabase,
+            session: {
+                access_token: "token",
+                expires_at: futureTimestamp(),
+                user: { id: "user-123" } as any,
+            },
+        });
+
+        const response = await GET(new Request("http://localhost/api/votes?productId=product-1"));
+        const payload = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(payload).toEqual({ votes: 5, userVoted: true });
+    });
+
+    it("removes a vote when requested by an authenticated user", async () => {
+        const supabase = createSupabaseMock([
+            createSelectBuilder({ data: { id: "vote-1" }, error: null }),
+            createDeleteBuilder({ error: null }),
+            createSelectBuilder({ count: 0, error: null }),
+        ]);
+
+        mockedSupabaseRoute.mockResolvedValue({
+            supabase,
+            session: {
+                access_token: "token",
+                expires_at: futureTimestamp(),
+                user: { id: "user-123" } as any,
+            },
+        });
+
+        const request = new Request("http://localhost/api/votes", {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ productId: "product-1" }),
+        });
+
+        const response = await DELETE(request);
+        const payload = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(payload).toEqual({
+            message: "Ton like a bien été retiré.",
+            votes: 0,
+        });
+    });
+});
+


### PR DESCRIPTION
## Summary
- replace the manual Supabase cookie parsing with the official route handler client so authenticated sessions are recovered reliably
- log the detected Supabase cookies and resolved session details for easier diagnosis of 401 errors
- adapt the vote route tests to cover both session-backed users and the Supabase fallback lookup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd42eb35588321a17238b394608ed1