### PR TITLE
feat: center green accents on hover

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -23,13 +23,17 @@ export default function AdminPage() {
         <div className="min-h-screen flex bg-gray-50">
             {/* Sidecar */}
             <nav className="w-64 min-h-screen flex flex-col bg-white border-r border-gray-200 shadow-md pt-12 pb-8 px-4">
-                <h2 className="font-black text-xl uppercase mb-10 text-black">Panneau admin</h2>
+                <h2 className="font-black text-xl uppercase mb-10 text-accent">Panneau admin</h2>
                 <ul className="flex-1 flex flex-col gap-2">
                     {sections.map((s) => (
                         <li key={s.id}>
                             <Button
                                 variant={selected === s.id ? "default" : "ghost"}
-                                className={`w-full justify-start rounded-lg font-semibold transition ${selected === s.id ? "bg-black text-white" : "text-black"}`}
+                                className={`w-full justify-start rounded-lg font-semibold transition border border-transparent ${
+                                    selected === s.id
+                                        ? "bg-accent text-black hover:bg-accent"
+                                        : "text-accent hover:text-accent-muted hover:bg-accent-muted"
+                                }`}
                                 onClick={() => setSelected(s.id)}
                             >
                                 {s.label}
@@ -39,7 +43,7 @@ export default function AdminPage() {
                 </ul>
                 <div className="mt-auto">
                     <Link href="/">
-                        <Button variant="outline" className="w-full rounded-full">
+                        <Button variant="outline" className="w-full rounded-full border border-accent text-accent hover:text-accent-muted hover:bg-accent-muted">
                             Retour au site
                         </Button>
                     </Link>
@@ -51,14 +55,14 @@ export default function AdminPage() {
                 <div className="w-full max-w-6xl flex-1 mx-auto bg-white rounded-2xl shadow p-10 min-h-[70vh] flex flex-col">
                     {selected === "orders" && (
                         <div>
-                            <h3 className="font-bold text-2xl mb-8">Gestion des commandes</h3>
+                            <h3 className="font-bold text-2xl mb-8 text-accent">Gestion des commandes</h3>
                             <p className="text-gray-400">Module à venir...</p>
                         </div>
                     )}
 
                     {selected === "users" && (
                         <div className="flex-1 flex flex-col">
-                            <h3 className="font-bold text-2xl mb-8">Gestion des utilisateurs</h3>
+                            <h3 className="font-bold text-2xl mb-8 text-accent">Gestion des utilisateurs</h3>
                             <div className="flex-1 w-full">
                                 <UsersTable />
                             </div>
@@ -67,7 +71,7 @@ export default function AdminPage() {
 
                     {selected === "products" && (
                         <div className="flex-1 flex flex-col">
-                            <h3 className="font-bold text-2xl mb-8">Gestion des produits</h3>
+                            <h3 className="font-bold text-2xl mb-8 text-accent">Gestion des produits</h3>
                             <div className="flex-1 w-full">
                                 <ProductsTable />
                             </div>
@@ -76,7 +80,7 @@ export default function AdminPage() {
 
                     {selected === "likes" && ( // 👈 NEW
                         <div className="flex-1 flex flex-col">
-                            <h3 className="font-bold text-2xl mb-8">Votes (likes) par produit</h3>
+                            <h3 className="font-bold text-2xl mb-8 text-accent">Votes (likes) par produit</h3>
                             <div className="flex-1 w-full">
                                 <AdminLikesTable />
                             </div>
@@ -85,7 +89,7 @@ export default function AdminPage() {
 
                     {selected === "submissions" && (
                         <div className="flex-1 flex flex-col">
-                            <h3 className="font-bold text-2xl mb-8">Soumissions Communauté</h3>
+                            <h3 className="font-bold text-2xl mb-8 text-accent">Soumissions Communauté</h3>
                             <div className="flex-1 w-full">
                                 <SubmissionsTable />
                             </div>

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -14,21 +14,23 @@ export default function CartPage() {
         <div className="flex flex-col min-h-screen bg-white">
             <Header />
             <main className="flex-1 max-w-3xl mx-auto w-full px-4 py-12">
-                <h1 className="text-2xl font-bold mb-8">Mon panier</h1>
+                <h1 className="text-2xl font-bold mb-8 text-accent">Mon panier</h1>
                 {count === 0 ? (
                     <div className="text-gray-600 text-center mt-16">
                         Ton panier est vide.
                         <div className="mt-6">
                             <Link href="/products">
-                                <Button className="rounded-full px-8 py-3 font-bold">Voir le catalogue</Button>
+                                <Button className="rounded-full px-8 py-3 font-bold border border-accent bg-black text-white transition-colors hover:bg-accent hover:text-black">
+                                    Voir le catalogue
+                                </Button>
                             </Link>
                         </div>
                     </div>
                 ) : (
                     <div className="space-y-6">
                         <div className="flex justify-between items-center">
-                            <h2 className="text-xl font-semibold">Mon panier ({count})</h2>
-                            <Button variant="ghost" onClick={clearCart} className="text-sm">
+                            <h2 className="text-xl font-semibold text-accent">Mon panier ({count})</h2>
+                            <Button variant="ghost" onClick={clearCart} className="text-sm text-accent hover:text-accent-muted">
                                 Vider le panier
                             </Button>
                         </div>
@@ -48,39 +50,42 @@ export default function CartPage() {
                                     <div className="font-semibold mt-2">{item.price} € x {item.quantity}</div>
                                 </div>
                                 <div className="flex items-center gap-2">
-                                    <Button
-                                        variant="outline"
-                                        size="icon"
-                                        onClick={() => updateQuantity(item.productId, item.size, item.quantity - 1)}
-                                        aria-label="Diminuer la quantité"
-                                    >
-                                        <Minus className="h-4 w-4" />
-                                    </Button>
-                                    <span className="w-8 text-center font-semibold">{item.quantity}</span>
-                                    <Button
-                                        variant="outline"
-                                        size="icon"
-                                        onClick={() => updateQuantity(item.productId, item.size, item.quantity + 1)}
-                                        aria-label="Augmenter la quantité"
-                                    >
-                                        <Plus className="h-4 w-4" />
-                                    </Button>
-                                </div>
                                 <Button
-                                    variant="ghost"
+                                    variant="outline"
                                     size="icon"
-                                    onClick={() => removeFromCart(item.productId, item.size)}
-                                    aria-label="Retirer l'article"
+                                    onClick={() => updateQuantity(item.productId, item.size, item.quantity - 1)}
+                                    aria-label="Diminuer la quantité"
+                                    className="border border-accent text-accent hover:bg-accent hover:text-black"
                                 >
-                                    <Trash2 className="h-5 w-5" />
+                                    <Minus className="h-4 w-4" />
+                                </Button>
+                                    <span className="w-8 text-center font-semibold">{item.quantity}</span>
+                                <Button
+                                    variant="outline"
+                                    size="icon"
+                                    onClick={() => updateQuantity(item.productId, item.size, item.quantity + 1)}
+                                    aria-label="Augmenter la quantité"
+                                    className="border border-accent text-accent hover:bg-accent hover:text-black"
+                                >
+                                    <Plus className="h-4 w-4" />
                                 </Button>
                             </div>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => removeFromCart(item.productId, item.size)}
+                                aria-label="Retirer l'article"
+                                className="text-accent hover:text-accent-muted"
+                            >
+                                <Trash2 className="h-5 w-5" />
+                            </Button>
+                        </div>
                         ))}
                         <div className="flex justify-between items-center border-t pt-6 mt-6">
                             <div className="text-xl font-bold">Total</div>
                             <div className="text-xl font-bold">{total} €</div>
                         </div>
-                        <Button className="w-full rounded-full py-4 text-lg font-bold">
+                        <Button className="w-full rounded-full py-4 text-lg font-bold border border-accent bg-black text-white transition-colors hover:bg-accent hover:text-black">
                             Passer la précommande
                         </Button>
                     </div>

--- a/src/app/cgu/page.tsx
+++ b/src/app/cgu/page.tsx
@@ -16,7 +16,7 @@ export default function CguPage() {
 
                 <div className="space-y-12 text-gray-800 leading-relaxed">
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Objet</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Objet</h2>
                         <p>
                             Les présentes CGU définissent les conditions d’accès et d’utilisation du site Add-Last. En accédant au
                             site, vous acceptez ces conditions sans réserve.
@@ -24,7 +24,7 @@ export default function CguPage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Accès au site</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Accès au site</h2>
                         <p>
                             Le site est accessible 24h/24 et 7j/7, sauf interruption pour maintenance ou cas de force majeure. Add-Last
                             ne saurait être tenu responsable des interruptions ou dysfonctionnements liés à Internet.
@@ -32,7 +32,7 @@ export default function CguPage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Compte utilisateur</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Compte utilisateur</h2>
                         <p>
                             Pour accéder à certaines fonctionnalités, vous devez créer un compte. Vous êtes responsable de la confidentialité
                             de vos identifiants et de toutes les activités réalisées avec votre compte.
@@ -40,7 +40,7 @@ export default function CguPage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Utilisation du site</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Utilisation du site</h2>
                         <p>
                             Vous vous engagez à utiliser le site de manière loyale et légale. Toute utilisation frauduleuse ou abusive
                             pourra entraîner la suspension ou la suppression de votre compte.
@@ -48,7 +48,7 @@ export default function CguPage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Propriété intellectuelle</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Propriété intellectuelle</h2>
                         <p>
                             Les contenus du site (textes, images, logos, codes) sont protégés par le droit de la propriété intellectuelle.
                             Toute reproduction sans autorisation est interdite.
@@ -56,17 +56,17 @@ export default function CguPage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Données personnelles</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Données personnelles</h2>
                         <p>
                             Le traitement de vos données est encadré par notre{" "}
-                            <a href="/confidentialite" className="text-black underline">
+                            <a href="/confidentialite" className="text-black underline transition-colors hover:text-accent">
                                 politique de confidentialité
                             </a>.
                         </p>
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Responsabilité</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Responsabilité</h2>
                         <p>
                             Add-Last met tout en œuvre pour assurer l’exactitude des informations publiées. Nous ne saurions toutefois être
                             responsables des erreurs, omissions ou dommages liés à l’utilisation du site.
@@ -74,10 +74,10 @@ export default function CguPage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Contact</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Contact</h2>
                         <p>
                             Pour toute question relative aux présentes CGU, vous pouvez nous écrire à :{" "}
-                            <a href="mailto:contact@add-last.com" className="text-black underline">
+                            <a href="mailto:contact@add-last.com" className="text-black underline transition-colors hover:text-accent">
                                 contact@add-last.com
                             </a>.
                         </p>

--- a/src/app/cgv/page.tsx
+++ b/src/app/cgv/page.tsx
@@ -16,7 +16,7 @@ export default function CgvPage() {
 
                 <div className="space-y-12 text-gray-800 leading-relaxed">
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Préambule</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Préambule</h2>
                         <p>
                             Toute commande passée sur le site Add-Last implique l’acceptation pleine et entière des présentes
                             Conditions Générales de Vente (CGV).
@@ -24,7 +24,7 @@ export default function CgvPage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Produits et disponibilité</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Produits et disponibilité</h2>
                         <p>
                             Les produits proposés sont décrits et présentés avec la plus grande exactitude. Ils sont disponibles
                             dans la limite des stocks existants. Les photos sont non contractuelles.
@@ -32,7 +32,7 @@ export default function CgvPage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Prix</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Prix</h2>
                         <p>
                             Les prix affichés sont en euros, toutes taxes comprises, hors frais de livraison. Les frais applicables
                             sont précisés avant validation de la commande.
@@ -40,7 +40,7 @@ export default function CgvPage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Commandes et paiement</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Commandes et paiement</h2>
                         <p>
                             La commande devient définitive après confirmation du paiement. Les règlements sont acceptés par carte
                             bancaire et via les prestataires sécurisés indiqués. Add-Last se réserve le droit d’annuler toute
@@ -49,17 +49,17 @@ export default function CgvPage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Livraison</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Livraison</h2>
                         <p>
                             Les modalités et délais de livraison sont détaillés dans notre{" "}
-                            <a href="/livraison" className="text-black underline">
+                            <a href="/livraison" className="text-black underline transition-colors hover:text-accent">
                                 politique de livraison
                             </a>.
                         </p>
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Droit de rétractation</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Droit de rétractation</h2>
                         <p>
                             Conformément au Code de la consommation, vous disposez d’un délai de 14 jours à compter de la réception
                             pour exercer votre droit de rétractation, sans justification ni pénalité.
@@ -67,17 +67,17 @@ export default function CgvPage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Garanties</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Garanties</h2>
                         <p>
                             Nos produits bénéficient des garanties légales de conformité et contre les vices cachés.
                         </p>
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Service client</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Service client</h2>
                         <p>
                             Pour toute question ou réclamation, contactez-nous à :{" "}
-                            <a href="mailto:contact@add-last.com" className="text-black underline">
+                            <a href="mailto:contact@add-last.com" className="text-black underline transition-colors hover:text-accent">
                                 contact@add-last.com
                             </a>.
                         </p>

--- a/src/app/confidentialite/page.tsx
+++ b/src/app/confidentialite/page.tsx
@@ -16,7 +16,7 @@ export default function PolitiqueConfidentialitePage() {
 
                 <div className="space-y-12 text-gray-800 leading-relaxed">
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Introduction</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Introduction</h2>
                         <p>
                             Nous nous engageons à protéger votre vie privée. En utilisant ce site, vous acceptez le traitement de vos
                             données conformément à cette politique.
@@ -24,7 +24,7 @@ export default function PolitiqueConfidentialitePage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Principes de Protection</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Principes de Protection</h2>
                         <ul className="list-disc list-inside space-y-2">
                             <li>Traitement légal, juste et transparent</li>
                             <li>Collecte limitée à l’objectif</li>
@@ -34,7 +34,7 @@ export default function PolitiqueConfidentialitePage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Droits des Utilisateurs</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Droits des Utilisateurs</h2>
                         <ul className="list-disc list-inside space-y-2">
                             <li>Droit d’accès, rectification et suppression</li>
                             <li>Droit d’opposition et de limitation</li>
@@ -44,7 +44,7 @@ export default function PolitiqueConfidentialitePage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Cookies</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Cookies</h2>
                         <p>
                             Nous utilisons des cookies pour analyser l’usage du site et améliorer l’expérience utilisateur.
                             Vous pouvez gérer vos préférences dans votre navigateur.
@@ -52,10 +52,10 @@ export default function PolitiqueConfidentialitePage() {
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Contact</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Contact</h2>
                         <p>
                             Pour toute question concernant vos données, contactez-nous à :{" "}
-                            <a href="mailto:atrewind404@gmail.com" className="text-black underline">
+                            <a href="mailto:atrewind404@gmail.com" className="text-black underline transition-colors hover:text-accent">
                                 atrewind404@gmail.com
                             </a>
                         </p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,6 +85,8 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --accent-color: #7CFF6B;
+  --accent-color-muted: #68F081;
 }
 
 .dark {
@@ -119,6 +121,8 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  --accent-color: #7CFF6B;
+  --accent-color-muted: #4ED760;
 }
 
 @layer base {
@@ -127,5 +131,64 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+  a {
+    color: var(--foreground);
+    transition: color 150ms ease;
+  }
+  a:hover {
+    color: var(--accent-color);
+  }
+}
+
+@layer utilities {
+  .text-accent {
+    color: var(--foreground);
+    transition: color 150ms ease;
+  }
+
+  .text-accent-muted {
+    color: var(--foreground);
+    transition: color 150ms ease;
+  }
+
+  .border-accent {
+    border-color: var(--foreground);
+    transition: border-color 150ms ease;
+  }
+
+  .bg-accent {
+    background-color: var(--accent-color);
+  }
+
+  .bg-accent-muted {
+    background-color: var(--accent-color-muted);
+  }
+
+  .hover\:text-accent:hover,
+  .group:hover .group-hover\:text-accent {
+    color: var(--accent-color);
+  }
+
+  .hover\:text-accent-muted:hover,
+  .group:hover .group-hover\:text-accent-muted {
+    color: var(--accent-color-muted);
+  }
+
+  .hover\:border-accent:hover,
+  .group:hover .group-hover\:border-accent {
+    border-color: var(--accent-color);
+  }
+
+  .hover\:bg-accent:hover {
+    background-color: var(--accent-color);
+  }
+
+  .hover\:bg-accent-muted:hover {
+    background-color: var(--accent-color-muted);
+  }
+
+  .focus-visible\:ring-accent:focus-visible {
+    --tw-ring-color: var(--accent-color);
   }
 }

--- a/src/app/mentions-legales/page.tsx
+++ b/src/app/mentions-legales/page.tsx
@@ -16,43 +16,43 @@ export default function MentionsLegalesPage() {
 
                 <div className="space-y-12 text-gray-800 leading-relaxed">
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Éditeur</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Éditeur</h2>
                         <p className="font-medium">Add-Last SAS</p>
                         <p>44 avenue Barbes, 93420 Villepinte</p>
                         <p>Capital social : 1000€</p>
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Gérance</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Gérance</h2>
                         <p><span className="font-medium">Président :</span> MERCIER Thibault</p>
                         <p><span className="font-medium">Directeur général :</span> MARTINEAU Alexis</p>
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Hébergeur</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Hébergeur</h2>
                         <p>Le site est hébergé par Vercel Inc., 340 S Lemon Ave #4133, Walnut, CA 91789, États-Unis</p>
                         <a
                             href="https://vercel.com"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-black underline"
+                            className="text-black underline transition-colors hover:text-accent"
                         >
                             → Visiter Vercel
                         </a>
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">Propriété Intellectuelle</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">Propriété Intellectuelle</h2>
                         <p>
                             Toute reproduction ou représentation du contenu doit faire l’objet d’une autorisation préalable.
                         </p>
                     </section>
 
                     <section>
-                        <h2 className="text-xl font-semibold border-l-4 border-black pl-4 mb-4">RGPD</h2>
+                        <h2 className="text-xl font-semibold border-l-4 border-black text-black pl-4 mb-4">RGPD</h2>
                         <p>
                             Pour toute question relative à vos données, consultez notre{" "}
-                            <a href="/confidentialite" className="text-black underline">
+                            <a href="/confidentialite" className="text-black underline transition-colors hover:text-accent">
                                 politique de confidentialité
                             </a>.
                         </p>

--- a/src/app/precommandes/page.tsx
+++ b/src/app/precommandes/page.tsx
@@ -59,8 +59,8 @@ export default function PrecommandesPage() {
             {/* Hero */}
             <section className="py-20 px-4 text-center border-b border-border bg-white">
                 <div className="max-w-4xl mx-auto">
-                    <h1 className="text-4xl md:text-6xl font-bold mb-6">
-                        Campagnes de <span className="italic">précommande</span>
+                    <h1 className="text-4xl md:text-6xl font-bold mb-6 text-accent">
+                        Campagnes de <span className="italic text-accent-muted">précommande</span>
                     </h1>
                     <p className="text-lg md:text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
                         Soutenez la réédition de modèles rares. Payez un acompte sécurisé pour garantir votre paire.
@@ -88,14 +88,14 @@ export default function PrecommandesPage() {
                                 Actuellement, aucune paire n’a encore atteint le quota nécessaire pour passer en précommande.
                             </p>
                             <Link href="/votes">
-                                <Button className="bg-black text-white hover:bg-white hover:text-black border border-black">
+                                <Button className="bg-black text-white border border-accent transition-colors hover:bg-accent hover:text-black">
                                     Aller voter pour changer ça
                                 </Button>
                             </Link>
                         </div>
                     ) : (
                         <>
-                            <h2 className="text-3xl font-bold mb-12">Sneakers en cours de précommande</h2>
+                            <h2 className="text-3xl font-bold mb-12 text-accent">Sneakers en cours de précommande</h2>
                             <div
                                 className={`
                   grid gap-6
@@ -122,7 +122,7 @@ export default function PrecommandesPage() {
 function PrecommandeCard({ product }: { product: Product }) {
     return (
         <Link href={`/products/${product.id}`} className="block group">
-            <Card className="border border-black/20 hover:border-black transition-all duration-300 bg-white h-full">
+            <Card className="border border-border hover:border-accent transition-all duration-300 bg-white h-full">
                 <CardHeader className="pb-2">
                     <div className="relative aspect-square overflow-hidden rounded-xl bg-neutral-100">
                         <img
@@ -131,14 +131,14 @@ function PrecommandeCard({ product }: { product: Product }) {
                             className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
                         />
                     </div>
-                    <CardTitle className="mt-3 text-lg font-semibold truncate">
+                    <CardTitle className="mt-3 text-lg font-semibold truncate text-accent group-hover:text-accent-muted transition-colors">
                         {product.title || product.name}
                     </CardTitle>
                 </CardHeader>
                 <CardContent className="flex flex-col gap-4">
                     <div className="flex items-center justify-between">
                         <span className="font-bold text-xl">{product.price}€</span>
-                        <Button size="sm" className="bg-black text-white hover:bg-white hover:text-black border border-black">
+                        <Button size="sm" className="bg-black text-white border border-accent transition-colors hover:bg-accent hover:text-black">
                             <ShoppingCart className="w-4 h-4 mr-2" /> Précommander
                         </Button>
                     </div>

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -250,9 +250,9 @@ export default function ProductPage() {
                     <div
                         className={`w-full text-center text-xs font-medium uppercase rounded-md py-2 border ${
                             percent >= 100
-                                ? "bg-white text-black border-black"
+                                ? "bg-white text-accent border-accent"
                                 : product.status === "En vote"
-                                    ? "bg-black text-white border-black"
+                                    ? "bg-accent text-black border-accent"
                                     : "bg-neutral-200 text-neutral-600 border-neutral-300"
                         }`}
                     >
@@ -261,9 +261,9 @@ export default function ProductPage() {
 
                     {/* Infos produit */}
                     <div>
-                        <h1 className="text-3xl font-bold">{product.title}</h1>
+                        <h1 className="text-3xl font-bold text-accent">{product.title}</h1>
                         <div className="text-lg text-muted-foreground">{product.brand}</div>
-                        <div className="text-2xl font-semibold mt-2">{product.price} €</div>
+                        <div className="text-2xl font-semibold mt-2 text-accent">{product.price} €</div>
                     </div>
 
                     {/* Progress votes */}
@@ -283,11 +283,13 @@ export default function ProductPage() {
                             variant={userVoted ? "default" : "outline"}
                             disabled={voteLoading}
                             onClick={handleVote}
-                            className="w-full"
+                            className={`w-full border border-accent transition-colors ${
+                                userVoted ? "bg-accent text-black hover:bg-accent" : "hover:bg-accent hover:text-black"
+                            }`}
                             aria-label={userVoted ? "Retirer mon like" : "Voter pour cette paire"}
                             aria-pressed={userVoted}
                         >
-                            <Heart className="w-5 h-5 mr-2" fill={userVoted ? "#000000" : "none"} />
+                            <Heart className="w-5 h-5 mr-2" fill={userVoted ? "#7CFF6B" : "none"} color="#7CFF6B" />
                             {userVoted ? "Retirer mon like" : "Voter pour cette paire"}
                         </Button>
                     )}
@@ -298,7 +300,7 @@ export default function ProductPage() {
                             <div>
                                 <div className="mb-2 font-medium flex items-center justify-between">
                                     <span>Votre taille</span>
-                                    <Button variant="outline" size="sm" onClick={() => setShowGuide(true)}>
+                                    <Button variant="outline" size="sm" onClick={() => setShowGuide(true)} className="border border-accent text-accent hover:bg-accent hover:text-black">
                                         Guide des tailles
                                     </Button>
                                 </div>

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -81,9 +81,9 @@ export default function ProductsPage() {
             <Header />
 
             {/* Hero */}
-            <section className="w-full border-b border-black/10 pt-16 pb-12 px-4 text-center">
+            <section className="w-full border-b border-border pt-16 pb-12 px-4 text-center">
                 <div className="max-w-3xl mx-auto space-y-6">
-                    <h1 className="text-4xl md:text-6xl font-bold tracking-tight">
+                    <h1 className="text-4xl md:text-6xl font-bold tracking-tight text-accent">
                         Catalogue des Sneakers
                     </h1>
                     <p className="text-lg text-black/70 leading-relaxed">
@@ -92,14 +92,14 @@ export default function ProductsPage() {
                         Pour voter ou précommander, rendez-vous dans les sections{" "}
                         <Link
                             href="/votes"
-                            className="font-medium underline underline-offset-4 hover:text-black transition-colors"
+                            className="font-medium underline underline-offset-4 text-accent hover:text-accent-muted transition-colors"
                         >
                             Votes
                         </Link>{" "}
                         et{" "}
                         <Link
                             href="/precommandes"
-                            className="font-medium underline underline-offset-4 hover:text-black transition-colors"
+                            className="font-medium underline underline-offset-4 text-accent hover:text-accent-muted transition-colors"
                         >
                             Précommandes
                         </Link>.
@@ -117,13 +117,13 @@ export default function ProductsPage() {
                         placeholder="Rechercher une paire…"
                         value={search}
                         onChange={(e) => setSearch(e.target.value)}
-                        className="w-full lg:w-[300px] border-black/30 transition-all duration-300 focus:ring-2 focus:ring-black/60"
+                        className="w-full lg:w-[300px] border border-border transition-all duration-300 focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent"
                     />
 
                     {/* Selects filtres */}
                     <div className="flex flex-wrap gap-4">
                         <Select onValueChange={(val) => setBrandFilter(val)} value={brandFilter}>
-                            <SelectTrigger className="w-[180px] border-black/30">
+                            <SelectTrigger className="w-[180px] border border-border focus:border-accent">
                                 <SelectValue placeholder="Filtrer par marque" />
                             </SelectTrigger>
                             <SelectContent>
@@ -140,7 +140,7 @@ export default function ProductsPage() {
                             value={modelFilter}
                             disabled={!brandFilter}
                         >
-                            <SelectTrigger className="w-[200px] border-black/30 disabled:opacity-50">
+                            <SelectTrigger className="w-[200px] border border-border disabled:opacity-50 focus:border-accent">
                                 <SelectValue placeholder="Filtrer par modèle" />
                             </SelectTrigger>
                             <SelectContent>
@@ -155,7 +155,7 @@ export default function ProductsPage() {
                         {(brandFilter || modelFilter || search) && (
                             <Button
                                 variant="ghost"
-                                className="flex items-center gap-2 hover:bg-black/5"
+                                className="flex items-center gap-2 text-accent hover:text-accent-muted hover:bg-accent-muted"
                                 onClick={() => {
                                     setBrandFilter("");
                                     setModelFilter("");
@@ -170,11 +170,11 @@ export default function ProductsPage() {
 
                 {/* Grille produits */}
                 {loading ? (
-                    <div className="flex justify-center items-center h-40 text-black/70">
+                    <div className="flex justify-center items-center h-40 text-accent">
                         <Loader2 className="animate-spin mr-2" /> Chargement…
                     </div>
                 ) : filtered.length === 0 ? (
-                    <div className="text-center text-black/60 py-24">
+                    <div className="text-center text-accent py-24">
                         Aucun produit trouvé.
                     </div>
                 ) : (
@@ -186,7 +186,7 @@ export default function ProductsPage() {
                 )}
 
                 {/* CTA proposer une paire */}
-                <div className="text-center space-y-4 pt-12 border-t border-black/10">
+                <div className="text-center space-y-4 pt-12 border-t border-border">
                     <p className="text-black/70">
                         Une paire que vous aimeriez revoir ? Proposez-la, notre équipe
                         analysera vos suggestions pour de futures campagnes.
@@ -194,7 +194,7 @@ export default function ProductsPage() {
                     <Link href="/proposer">
                         <Button
                             size="lg"
-                            className="gap-2 bg-black text-white hover:bg-white hover:text-black border-2 border-black transition-all duration-300 px-8 py-3 text-base font-medium tracking-wide"
+                            className="gap-2 px-8 py-3 text-base font-medium tracking-wide"
                         >
                             <PlusCircle size={18} /> Proposer une paire
                         </Button>
@@ -211,7 +211,7 @@ export default function ProductsPage() {
 function ProductCard({ product }: { product: Product }) {
     return (
         <Link href={`/products/${product.id}`} className="block group">
-            <Card className="border border-black/20 bg-white hover:shadow-xl hover:scale-[1.02] transition-transform duration-300">
+            <Card className="border border-border bg-white hover:border-accent hover:shadow-xl hover:scale-[1.02] transition-transform duration-300">
                 <CardHeader className="pb-2">
                     <div className="relative aspect-square overflow-hidden rounded-lg bg-black/5">
                         <img
@@ -220,7 +220,7 @@ function ProductCard({ product }: { product: Product }) {
                             className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                         />
                     </div>
-                    <CardTitle className="mt-3 text-lg font-semibold truncate text-black group-hover:text-black/80 transition-colors">
+                    <CardTitle className="mt-3 text-lg font-semibold truncate text-accent group-hover:text-accent-muted transition-colors">
                         {product.title}
                     </CardTitle>
                 </CardHeader>

--- a/src/app/votes/page.tsx
+++ b/src/app/votes/page.tsx
@@ -47,8 +47,8 @@ export default function VotesPage() {
             {/* Hero Section */}
             <section className="py-16 px-4 text-center border-b border-border">
                 <div className="max-w-4xl mx-auto">
-                    <h1 className="text-4xl md:text-6xl font-bold mb-6">
-                        Votez pour vos <span className="italic">sneakers</span> préférées
+                    <h1 className="text-4xl md:text-6xl font-bold mb-6 text-accent">
+                        Votez pour vos <span className="italic text-accent-muted">sneakers</span> préférées
                     </h1>
                     <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
                         Choisissez jusqu’à 2 paires maximum et suivez leur progression vers la précommande.
@@ -74,8 +74,8 @@ export default function VotesPage() {
             <section className="py-16 px-4">
                 <div className="max-w-6xl mx-auto">
                     <div className="flex items-center gap-3 mb-12">
-                        <Trophy className="w-8 h-8" />
-                        <h2 className="text-3xl font-bold">Classement des votes</h2>
+                        <Trophy className="w-8 h-8 text-accent" />
+                        <h2 className="text-3xl font-bold text-accent">Classement des votes</h2>
                     </div>
                     <div className="grid md:grid-cols-3 gap-8">
                         {products.slice(0, 3).map((p) => (
@@ -88,7 +88,7 @@ export default function VotesPage() {
             {/* All products */}
             <section className="py-16 px-4 bg-muted/30">
                 <div className="max-w-6xl mx-auto">
-                    <h2 className="text-3xl font-bold mb-12">Toutes les sneakers</h2>
+                    <h2 className="text-3xl font-bold mb-12 text-accent">Toutes les sneakers</h2>
                     <div className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
                         {products.map((p) => (
                             <VoteCard key={p.id} product={p} user={user} small />
@@ -100,7 +100,7 @@ export default function VotesPage() {
             {/* CTA vers les précommandes */}
             <div className="mt-10 flex justify-center">
                 <Link href="/precommandes">
-                    <Button className="bg-black text-white hover:bg-white hover:text-black border border-black px-6 py-3 text-lg">
+                    <Button className="bg-black text-white border border-accent transition-colors hover:bg-accent hover:text-black px-6 py-3 text-lg">
                         Voir les précommandes disponibles
                     </Button>
                 </Link>
@@ -235,7 +235,7 @@ function VoteCard({ product, user, small }: { product: Product; user: User | nul
 
     return (
         <Link href={`/products/${product.id}`} className="block group">
-            <Card className="border border-black/20 hover:border-black transition-all duration-300 bg-white">
+            <Card className="border border-border hover:border-accent transition-all duration-300 bg-white">
                 <CardHeader className="pb-2">
                     <div className="relative aspect-square overflow-hidden rounded-xl bg-neutral-100">
                         <img
@@ -247,7 +247,7 @@ function VoteCard({ product, user, small }: { product: Product; user: User | nul
                 </CardHeader>
                 <CardContent className="flex flex-col gap-4">
                     <div className="flex items-center justify-between">
-                        <CardTitle className="text-lg font-semibold truncate">{product.title}</CardTitle>
+                        <CardTitle className="text-lg font-semibold truncate text-accent group-hover:text-accent-muted transition-colors">{product.title}</CardTitle>
                         <Button
                             variant={userVoted ? "default" : "outline"}
                             disabled={loading}
@@ -255,8 +255,11 @@ function VoteCard({ product, user, small }: { product: Product; user: User | nul
                             size={small ? "sm" : "icon"}
                             aria-label={userVoted ? "Retirer mon like" : "Voter"}
                             aria-pressed={userVoted}
+                            className={`border border-accent transition-colors ${
+                                userVoted ? "bg-accent text-black hover:bg-accent" : "hover:bg-accent hover:text-black"
+                            }`}
                         >
-                            <Heart className="w-5 h-5" fill={userVoted ? "#000000" : "none"} />
+                            <Heart className="w-5 h-5" fill={userVoted ? "#7CFF6B" : "none"} color="#7CFF6B" />
                         </Button>
                     </div>
 

--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -103,9 +103,9 @@ export default function WishlistPage() {
             <main className="flex-1 flex flex-col items-center justify-center px-4 py-12">
                 {/* NON CONNECTÉ */}
                 {!user && (
-                    <div className="flex flex-col items-center w-full max-w-xl mx-auto py-16">
-                        <Heart className="w-12 h-12 text-black mb-3" fill="black" />
-                        <h2 className="text-2xl md:text-3xl font-bold text-center mb-4 tracking-tight">
+                    <div className="flex flex-col items-center w-full max-w-xl mx-auto py-16 text-center">
+                        <Heart className="w-12 h-12 text-black mb-3 transition-colors" />
+                        <h2 className="text-2xl md:text-3xl font-bold text-center mb-4 tracking-tight text-black">
                             UNE PAIRE VOUS FAIT DE L&apos;OEIL ? {/* ✅ apostrophe échappée */}
                         </h2>
                         <div className="text-gray-600 text-center text-lg md:text-xl mb-8 max-w-xl leading-snug">
@@ -114,12 +114,12 @@ export default function WishlistPage() {
                         </div>
                         <div className="flex flex-col sm:flex-row gap-4 w-full justify-center">
                             <Link href="/sign-up" className="w-full sm:w-auto">
-                                <Button className="rounded-full px-8 py-4 text-lg font-bold w-full sm:w-auto bg-black text-white hover:bg-gray-900">
+                                <Button className="rounded-full px-8 py-4 text-lg font-bold w-full sm:w-auto">
                                     CRÉER UN COMPTE
                                 </Button>
                             </Link>
                             <Link href="/sign-in" className="w-full sm:w-auto">
-                                <Button className="rounded-full px-8 py-4 text-lg font-bold w-full sm:w-auto bg-black text-white hover:bg-gray-900">
+                                <Button className="rounded-full px-8 py-4 text-lg font-bold w-full sm:w-auto">
                                     SE CONNECTER
                                 </Button>
                             </Link>
@@ -129,7 +129,7 @@ export default function WishlistPage() {
 
                 {/* LOADING */}
                 {user && loading && (
-                    <div className="flex flex-col items-center justify-center min-h-[30vh] text-xl text-gray-500">
+                    <div className="flex flex-col items-center justify-center min-h-[30vh] text-xl text-black">
                         Chargement…
                     </div>
                 )}
@@ -137,13 +137,15 @@ export default function WishlistPage() {
                 {/* CONNECTÉ, WISHLIST VIDE */}
                 {user && !loading && liked.length === 0 && (
                     <div className="flex flex-col items-center w-full max-w-xl mx-auto py-16">
-                        <Heart className="w-12 h-12 text-gray-400 mb-3" />
-                        <h2 className="text-2xl md:text-3xl font-bold text-center mb-3">Ta wishlist est vide</h2>
+                        <Heart className="w-12 h-12 text-black mb-3" />
+                        <h2 className="text-2xl md:text-3xl font-bold text-center mb-3 text-black">Ta wishlist est vide</h2>
                         <div className="text-gray-600 text-center mb-7 text-lg">
                             Like tes paires préférées pour les retrouver ici.
                         </div>
                         <Link href="/products">
-                            <Button className="rounded-full px-8 py-4 text-lg font-bold">Voir les produits</Button>
+                            <Button className="rounded-full px-8 py-4 text-lg font-bold">
+                                Voir les produits
+                            </Button>
                         </Link>
                     </div>
                 )}
@@ -151,14 +153,14 @@ export default function WishlistPage() {
                 {/* CONNECTÉ, AVEC LIKES */}
                 {user && !loading && liked.length > 0 && (
                     <div className="w-full max-w-4xl mx-auto py-6">
-                        <h1 className="text-2xl md:text-3xl font-bold mb-8 flex items-center gap-2 justify-center">
-                            <Heart className="w-7 h-7 text-black" fill="black" />
+                        <h1 className="text-2xl md:text-3xl font-bold mb-8 flex items-center gap-2 justify-center text-black">
+                            <Heart className="w-7 h-7 text-black" />
                             Mes paires likées
                         </h1>
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
                             {liked.map((prod) => (
                                 <Link href={`/products/${prod.id}`} key={prod.id} className="block group">
-                                    <div className="bg-white rounded-2xl shadow hover:shadow-xl hover:scale-[1.015] transition flex flex-col items-center p-5">
+                                    <div className="bg-white rounded-2xl shadow hover:shadow-xl hover:scale-[1.015] transition flex flex-col items-center p-5 border border-black/10 hover:border-accent">
                                         <div className="w-full aspect-[4/3] bg-gray-100 rounded-xl overflow-hidden mb-4 relative">
                                             <img
                                                 src={prod.images?.[0] || "/placeholder.svg"}
@@ -169,7 +171,7 @@ export default function WishlistPage() {
                                                 type="button"
                                                 size="icon"
                                                 variant="default"
-                                                className="absolute top-3 right-3 rounded-full border border-black bg-black text-white hover:bg-white hover:text-black"
+                                                className="absolute top-3 right-3 rounded-full"
                                                 onClick={(event) => {
                                                     event.preventDefault();
                                                     event.stopPropagation();
@@ -177,12 +179,14 @@ export default function WishlistPage() {
                                                 }}
                                                 aria-label="Retirer ce produit de mes likes"
                                             >
-                                                <Heart className="w-5 h-5" fill="currentColor" />
+                                                <Heart className="w-5 h-5 text-black" />
                                             </Button>
                                         </div>
-                                        <div className="font-bold text-lg mb-1 truncate w-full text-center">{prod.title}</div>
+                                        <div className="font-bold text-lg mb-1 truncate w-full text-center text-black transition-colors group-hover:text-accent">
+                                            {prod.title}
+                                        </div>
                                         <div className="text-gray-600 text-sm mb-2 w-full text-center">{prod.brand}</div>
-                                        <div className="font-semibold text-xl mb-2 w-full text-center">{prod.price} €</div>
+                                        <div className="font-semibold text-xl mb-2 w-full text-center text-black transition-colors group-hover:text-accent">{prod.price} €</div>
                                     </div>
                                 </Link>
                             ))}

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -10,7 +10,7 @@ export default function BackButton() {
             whileTap={{ scale: 0.98 }}
             transition={{ type: "spring", stiffness: 350 }}
         >
-            <Link href="/" className="group flex items-center gap-2 px-3 py-2 rounded-full bg-white/80 border border-gray-200 shadow hover:shadow-xl hover:bg-gray-100 transition-all backdrop-blur-lg">
+            <Link href="/" className="group flex items-center gap-2 px-3 py-2 rounded-full bg-white/80 border border-accent shadow hover:shadow-xl hover:bg-accent-muted transition-all backdrop-blur-lg">
                 <svg
                     width={26}
                     height={26}
@@ -20,11 +20,11 @@ export default function BackButton() {
                     strokeWidth={2.2}
                     strokeLinecap="round"
                     strokeLinejoin="round"
-                    className="text-gray-600 group-hover:text-black transition"
+                    className="text-accent group-hover:text-accent-muted transition"
                 >
                     <path d="M15 18l-6-6 6-6" />
                 </svg>
-                <span className="text-black group-hover:text-neutral-900 font-medium transition text-base hidden sm:block">
+                <span className="text-accent group-hover:text-accent-muted font-medium transition text-base hidden sm:block">
           Retour
         </span>
             </Link>

--- a/src/components/CatalogCarousel.tsx
+++ b/src/components/CatalogCarousel.tsx
@@ -43,10 +43,10 @@ export default function CatalogGrid({
                 {/* Titre centré avec underline hover */}
                 <div className="text-center mb-10 md:mb-12">
                     <span className="relative inline-block group">
-                        <h2 className="text-3xl md:text-4xl font-light tracking-wide text-black transition-colors duration-300 group-hover:text-gray-700">
+                        <h2 className="text-3xl md:text-4xl font-light tracking-wide text-accent transition-colors duration-300 group-hover:text-accent-muted">
                             {title}
                         </h2>
-                        <span className="pointer-events-none absolute left-0 -bottom-2 h-0.5 bg-black w-0 transition-all duration-300 group-hover:w-full"></span>
+                        <span className="pointer-events-none absolute left-0 -bottom-2 h-0.5 bg-accent w-0 transition-all duration-300 group-hover:w-full"></span>
                     </span>
                 </div>
 
@@ -65,7 +65,7 @@ export default function CatalogGrid({
                 {/* CTA centré sous les cards */}
                 <div className="text-center mt-10">
                     <Link href={ctaHref}>
-                        <Button className="bg-black text-white hover:bg-white hover:text-black border-2 border-black transition-all duration-300 px-8 py-3 text-base font-medium tracking-wide">
+                        <Button className="bg-black text-white border-2 border-accent transition-all duration-300 hover:bg-accent hover:text-black px-8 py-3 text-base font-medium tracking-wide">
                             Voir tout le catalogue
                         </Button>
                     </Link>
@@ -218,7 +218,7 @@ function GridCard({ product, user }: { product: Product; user: User | null }) {
             tabIndex={0}
             onClick={handleCardActivate}
             onKeyDown={handleCardKeyDown}
-            className="group cursor-pointer border border-black/20 hover:border-black transition-all duration-300 bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#7CFF6B]"
+            className="group cursor-pointer border border-border hover:border-accent transition-all duration-300 bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent"
         >
             <CardHeader className="pb-2">
                 {/* Image carrée */}
@@ -232,7 +232,7 @@ function GridCard({ product, user }: { product: Product; user: User | null }) {
                     />
                 </div>
 
-                <CardTitle className="mt-3 text-lg font-semibold truncate text-black">
+                <CardTitle className="mt-3 text-lg font-semibold truncate text-accent group-hover:text-accent-muted transition-colors">
                     {product.name}
                 </CardTitle>
                 <div className="text-sm text-neutral-500">{product.brand}</div>
@@ -240,7 +240,7 @@ function GridCard({ product, user }: { product: Product; user: User | null }) {
 
             <CardContent className="flex flex-col gap-4">
                 <div className="flex items-center justify-between">
-                    <span className="font-bold text-xl text-black">{product.price}€</span>
+                    <span className="font-bold text-xl text-accent">{product.price}€</span>
 
                     {/* Bouton like */}
                     <Button
@@ -250,13 +250,13 @@ function GridCard({ product, user }: { product: Product; user: User | null }) {
                         size="icon"
                         className={
                             userVoted
-                                ? "rounded-full w-12 h-12 bg-black text-white border-2 border-black hover:bg-white hover:text-black"
-                                : "rounded-full w-12 h-12 border-2 border-black text-black hover:bg-black hover:text-white"
+                                ? "rounded-full w-12 h-12 bg-accent text-black border-2 border-accent hover:bg-accent"
+                                : "rounded-full w-12 h-12 border-2 border-accent text-accent hover:bg-accent hover:text-black"
                         }
                         aria-label={userVoted ? "Retirer mon like" : "Voter"}
                         aria-pressed={userVoted}
                     >
-                        <Heart className="w-6 h-6 transition-all" fill={userVoted ? "#000000" : "none"} />
+                        <Heart className="w-6 h-6 transition-all" fill={userVoted ? "#7CFF6B" : "none"} color="#7CFF6B" />
                     </Button>
                 </div>
 
@@ -292,7 +292,7 @@ function GridCard({ product, user }: { product: Product; user: User | null }) {
                             Retente le mois prochain ou retire un vote depuis ton profil.
                         </p>
                     </div>
-                    <Button onClick={() => setShowModal(false)} className="mt-2 w-full">
+                    <Button onClick={() => setShowModal(false)} className="mt-2 w-full bg-black text-white border border-accent hover:bg-accent hover:text-black">
                         Fermer
                     </Button>
                 </DialogContent>
@@ -329,10 +329,10 @@ function StatusBand({
     const quotaAtteint = votesCount >= (goal_likes || 1)
 
     if (quotaAtteint) {
-        return <div className={`${base} bg-white text-black border-black`}>En précommande</div>
+        return <div className={`${base} bg-white text-accent border-accent`}>En précommande</div>
     }
     if (status === "En vote") {
-        return <div className={`${base} bg-black text-white border-black`}>En vote</div>
+        return <div className={`${base} bg-accent text-black border-accent`}>En vote</div>
     }
     return (
         <div className={`${base} bg-neutral-100 text-neutral-600 border-neutral-300`}>

--- a/src/components/ForgotPasswordForm.tsx
+++ b/src/components/ForgotPasswordForm.tsx
@@ -30,7 +30,7 @@ export default function ForgotPasswordForm() {
     return (
         <Card className="max-w-md w-full mx-auto shadow-2xl rounded-3xl border-0 bg-white/95">
             <CardHeader className="pt-10 pb-2 flex flex-col items-center gap-2">
-        <span className="text-3xl font-black tracking-tight uppercase text-black select-none">
+        <span className="text-3xl font-black tracking-tight uppercase text-accent select-none">
           addlast
         </span>
                 <CardTitle className="text-center text-2xl font-extrabold tracking-tight">
@@ -53,7 +53,7 @@ export default function ForgotPasswordForm() {
                     />
                     <Button
                         type="submit"
-                        className="w-full mt-2 rounded-full font-semibold transition hover:-translate-y-1 hover:shadow-xl"
+                        className="w-full mt-2 rounded-full font-semibold transition hover:-translate-y-1 hover:shadow-xl bg-black text-white border border-accent hover:bg-accent hover:text-black"
                         disabled={loading}
                     >
                         {loading ? "Envoi en cours..." : "Envoyer le lien de réinitialisation"}
@@ -62,7 +62,7 @@ export default function ForgotPasswordForm() {
                 <div className="text-sm mt-8 text-center">
                     <Link
                         href="/sign-in"
-                        className="text-black underline font-semibold hover:no-underline hover:text-neutral-700 transition"
+                        className="text-accent underline font-semibold hover:no-underline hover:text-accent-muted transition"
                     >
                         Retour à la connexion
                     </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -146,17 +146,17 @@ export default function Header() {
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent
                                     align="end"
-                                    className="w-56 shadow-xl rounded-2xl mt-2 border border-[#7CFF6B]/30 bg-black text-white"
+                                    className="w-56 shadow-xl rounded-2xl mt-2 border border-black/10 bg-white text-black"
                                 >
                                     <DropdownMenuItem
                                         asChild
-                                        className="focus:bg-[#7CFF6B]/20 focus:text-[#7CFF6B]"
+                                        className="transition-colors focus:bg-[#7CFF6B]/15 hover:text-[#7CFF6B] focus:text-[#7CFF6B]"
                                     >
                                         <Link href="/account">Mon profil</Link>
                                     </DropdownMenuItem>
                                     <DropdownMenuItem
                                         asChild
-                                        className="focus:bg-[#7CFF6B]/20 focus:text-[#7CFF6B]"
+                                        className="transition-colors focus:bg-[#7CFF6B]/15 hover:text-[#7CFF6B] focus:text-[#7CFF6B]"
                                     >
                                         <Link href="/orders">Mes commandes</Link>
                                     </DropdownMenuItem>
@@ -165,7 +165,7 @@ export default function Header() {
                                         <>
                                             <DropdownMenuItem
                                                 asChild
-                                                className="focus:bg-[#7CFF6B]/20 focus:text-[#7CFF6B]"
+                                                className="transition-colors focus:bg-[#7CFF6B]/15 hover:text-[#7CFF6B] focus:text-[#7CFF6B]"
                                             >
                                                 <Link href="/admin">Admin</Link>
                                             </DropdownMenuItem>
@@ -174,7 +174,7 @@ export default function Header() {
                                     )}
                                     <DropdownMenuItem
                                         onClick={handleLogout}
-                                        className="focus:bg-[#7CFF6B]/20 focus:text-[#7CFF6B]"
+                                        className="transition-colors focus:bg-[#7CFF6B]/15 hover:text-[#7CFF6B] focus:text-[#7CFF6B]"
                                     >
                                         Déconnexion
                                     </DropdownMenuItem>

--- a/src/components/HeroHowItWorks.tsx
+++ b/src/components/HeroHowItWorks.tsx
@@ -9,25 +9,25 @@ export default function HowItWorks() {
             <div className="max-w-7xl mx-auto">
                 {/* Title with hover underline animation */}
                 <div className="text-center mb-16 md:mb-24">
-          <span className="relative inline-block group">
-            <h2 className="text-4xl md:text-5xl lg:text-6xl font-bold text-black text-balance transition-colors duration-300 group-hover:text-gray-700">
-              Comment ça marche ?
-            </h2>
-            <span className="pointer-events-none absolute left-0 -bottom-2 h-0.5 bg-black w-0 transition-all duration-300 group-hover:w-full"></span>
-          </span>
+            <span className="relative inline-block group">
+              <h2 className="text-4xl md:text-5xl lg:text-6xl font-bold text-accent text-balance transition-colors duration-300 group-hover:text-accent-muted">
+                Comment ça marche ?
+              </h2>
+              <span className="pointer-events-none absolute left-0 -bottom-2 h-0.5 bg-accent w-0 transition-all duration-300 group-hover:w-full"></span>
+            </span>
                 </div>
 
                 {/* Steps Grid */}
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12 lg:gap-8 mb-16 md:mb-20">
                     {/* Step 1: Vote */}
-                    <div className="flex flex-col items-center text-center group animate-slide-up">
-                        <div className="w-16 h-16 md:w-20 md:h-20 mb-6 flex items-center justify-center border-2 border-black rounded-full transition-all duration-500 group-hover:bg-black group-hover:text-white group-hover:scale-110 group-hover:shadow-lg">
+                      <div className="flex flex-col items-center text-center group animate-slide-up">
+                          <div className="w-16 h-16 md:w-20 md:h-20 mb-6 flex items-center justify-center border-2 border-accent rounded-full transition-all duration-500 group-hover:bg-accent group-hover:text-black group-hover:scale-110 group-hover:shadow-lg">
                             <CheckCircle
                                 className="w-8 h-8 md:w-10 md:h-10 transition-transform duration-300 group-hover:rotate-12"
                                 strokeWidth={1.5}
                             />
                         </div>
-                        <h3 className="text-xl md:text-2xl font-bold text-black mb-4 transition-colors duration-300 group-hover:text-gray-800">
+                          <h3 className="text-xl md:text-2xl font-bold text-accent mb-4 transition-colors duration-300 group-hover:text-accent-muted">
                             Vote
                         </h3>
                         <p className="text-gray-600 text-base md:text-lg leading-relaxed max-w-xs transition-all duration-300 group-hover:text-gray-800">
@@ -36,14 +36,14 @@ export default function HowItWorks() {
                     </div>
 
                     {/* Step 2: Précommande */}
-                    <div className="flex flex-col items-center text-center group animate-slide-up animation-delay-200">
-                        <div className="w-16 h-16 md:w-20 md:h-20 mb-6 flex items-center justify-center border-2 border-black rounded-full transition-all duration-500 group-hover:bg-black group-hover:text-white group-hover:scale-110 group-hover:shadow-lg">
+                      <div className="flex flex-col items-center text-center group animate-slide-up animation-delay-200">
+                          <div className="w-16 h-16 md:w-20 md:h-20 mb-6 flex items-center justify-center border-2 border-accent rounded-full transition-all duration-500 group-hover:bg-accent group-hover:text-black group-hover:scale-110 group-hover:shadow-lg">
                             <Package
                                 className="w-8 h-8 md:w-10 md:h-10 transition-transform duration-300 group-hover:rotate-12"
                                 strokeWidth={1.5}
                             />
                         </div>
-                        <h3 className="text-xl md:text-2xl font-bold text-black mb-4 transition-colors duration-300 group-hover:text-gray-800">
+                          <h3 className="text-xl md:text-2xl font-bold text-accent mb-4 transition-colors duration-300 group-hover:text-accent-muted">
                             Précommande
                         </h3>
                         <p className="text-gray-600 text-base md:text-lg leading-relaxed max-w-xs transition-all duration-300 group-hover:text-gray-800">
@@ -52,14 +52,14 @@ export default function HowItWorks() {
                     </div>
 
                     {/* Step 3: Reçois */}
-                    <div className="flex flex-col items-center text-center group animate-slide-up animation-delay-400">
-                        <div className="w-16 h-16 md:w-20 md:h-20 mb-6 flex items-center justify-center border-2 border-black rounded-full transition-all duration-500 group-hover:bg-black group-hover:text-white group-hover:scale-110 group-hover:shadow-lg">
+                      <div className="flex flex-col items-center text-center group animate-slide-up animation-delay-400">
+                          <div className="w-16 h-16 md:w-20 md:h-20 mb-6 flex items-center justify-center border-2 border-accent rounded-full transition-all duration-500 group-hover:bg-accent group-hover:text-black group-hover:scale-110 group-hover:shadow-lg">
                             <Shield
                                 className="w-8 h-8 md:w-10 md:h-10 transition-transform duration-300 group-hover:rotate-12"
                                 strokeWidth={1.5}
                             />
                         </div>
-                        <h3 className="text-xl md:text-2xl font-bold text-black mb-4 transition-colors duration-300 group-hover:text-gray-800">
+                          <h3 className="text-xl md:text-2xl font-bold text-accent mb-4 transition-colors duration-300 group-hover:text-accent-muted">
                             Reçois
                         </h3>
                         <p className="text-gray-600 text-base md:text-lg leading-relaxed max-w-xs transition-all duration-300 group-hover:text-gray-800">
@@ -68,14 +68,14 @@ export default function HowItWorks() {
                     </div>
 
                     {/* Step 4: Collectionne */}
-                    <div className="flex flex-col items-center text-center group animate-slide-up animation-delay-600">
-                        <div className="w-16 h-16 md:w-20 md:h-20 mb-6 flex items-center justify-center border-2 border-black rounded-full transition-all duration-500 group-hover:bg-black group-hover:text-white group-hover:scale-110 group-hover:shadow-lg">
+                      <div className="flex flex-col items-center text-center group animate-slide-up animation-delay-600">
+                          <div className="w-16 h-16 md:w-20 md:h-20 mb-6 flex items-center justify-center border-2 border-accent rounded-full transition-all duration-500 group-hover:bg-accent group-hover:text-black group-hover:scale-110 group-hover:shadow-lg">
                             <Users
                                 className="w-8 h-8 md:w-10 md:h-10 transition-transform duration-300 group-hover:rotate-12"
                                 strokeWidth={1.5}
                             />
                         </div>
-                        <h3 className="text-xl md:text-2xl font-bold text-black mb-4 transition-colors duration-300 group-hover:text-gray-800">
+                          <h3 className="text-xl md:text-2xl font-bold text-accent mb-4 transition-colors duration-300 group-hover:text-accent-muted">
                             Collectionne
                         </h3>
                         <p className="text-gray-600 text-base md:text-lg leading-relaxed max-w-xs transition-all duration-300 group-hover:text-gray-800">
@@ -86,7 +86,7 @@ export default function HowItWorks() {
 
                 {/* CTA Button */}
                 <div className="flex justify-center animate-fade-in animation-delay-800">
-                    <Button size="lg" className="bg-black text-white hover:bg-white hover:text-black border-2 border-black transition-all duration-300 px-8 py-3 text-base font-medium tracking-wide">
+                    <Button size="lg" className="bg-black text-white border-2 border-accent transition-all duration-300 hover:bg-accent hover:text-black px-8 py-3 text-base font-medium tracking-wide">
                         Commencer à voter
                     </Button>
                 </div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -33,7 +33,7 @@ export default function HeroSection() {
                 {/* CTA Buttons */}
                 <div className="flex flex-col sm:flex-row gap-6 justify-center items-center">
                     <Link href="/catalogue">
-                        <Button size="lg" className="bg-black text-white hover:bg-white hover:text-black border-2 border-black transition-all duration-300 px-8 py-3 text-base font-medium tracking-wide">
+                        <Button size="lg" className="px-8 py-3 text-base font-medium tracking-wide">
                             Découvrir les paires
                         </Button>
                     </Link>

--- a/src/components/HomeHowItWorks.tsx
+++ b/src/components/HomeHowItWorks.tsx
@@ -2,7 +2,7 @@ export default function HomeHowItWorks() {
     return (
         <section className="py-14 bg-gray-50 border-t border-gray-100">
             <div className="max-w-3xl mx-auto px-4">
-                <h2 className="text-2xl md:text-3xl font-bold mb-7 text-center">Le process d’achat Addlast</h2>
+                <h2 className="text-2xl md:text-3xl font-bold mb-7 text-center text-accent">Le process d’achat Addlast</h2>
                 <ol className="space-y-6 text-lg text-gray-700">
                     <li>
                         <b>1. Vote :</b> Parcours le catalogue et like tes paires préférées.<br/>

--- a/src/components/HomeVideos.tsx
+++ b/src/components/HomeVideos.tsx
@@ -2,7 +2,7 @@ export default function HomeVideos() {
     return (
         <section className="py-12 bg-white border-y border-gray-100">
             <div className="max-w-4xl mx-auto px-4 flex flex-col items-center text-center gap-8">
-                <h2 className="text-2xl md:text-3xl font-bold">Micro-trottoir & Réseaux</h2>
+                <h2 className="text-2xl md:text-3xl font-bold text-accent">Micro-trottoir & Réseaux</h2>
                 <div className="w-full max-w-xl aspect-video rounded-xl overflow-hidden shadow">
                     {/* Remplace src par ta vraie vidéo Youtube ou autre */}
                     <iframe
@@ -15,8 +15,8 @@ export default function HomeVideos() {
                     ></iframe>
                 </div>
                 <div className="flex gap-6 justify-center">
-                    <a href="https://www.instagram.com/ton_insta/" target="_blank" rel="noopener noreferrer" className="text-lg font-semibold text-pink-500 hover:underline">Voir sur Instagram</a>
-                    <a href="https://www.tiktok.com/@ton_tiktok/" target="_blank" rel="noopener noreferrer" className="text-lg font-semibold text-black hover:underline">Voir sur TikTok</a>
+                    <a href="https://www.instagram.com/ton_insta/" target="_blank" rel="noopener noreferrer" className="text-lg font-semibold text-accent hover:text-accent-muted hover:underline">Voir sur Instagram</a>
+                    <a href="https://www.tiktok.com/@ton_tiktok/" target="_blank" rel="noopener noreferrer" className="text-lg font-semibold text-accent hover:text-accent-muted hover:underline">Voir sur TikTok</a>
                 </div>
             </div>
         </section>

--- a/src/components/HomeVoteCart.tsx
+++ b/src/components/HomeVoteCart.tsx
@@ -22,9 +22,9 @@ export default function HomeVoteCart({ products, user }: HomeVoteCartProps) {
         <section className="py-10 bg-gray-50">
             <div className="max-w-6xl mx-auto px-4">
                 <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
-                    <h2 className="text-2xl md:text-3xl font-bold mb-2 md:mb-0">Vote pour ta paire</h2>
+                    <h2 className="text-2xl md:text-3xl font-bold mb-2 md:mb-0 text-accent">Vote pour ta paire</h2>
                     <Link href="/products">
-            <span className="inline-block px-6 py-2 bg-black text-white font-semibold rounded-full text-base hover:bg-gray-900 transition">
+            <span className="inline-block px-6 py-2 bg-black text-white font-semibold rounded-full text-base border border-accent transition hover:bg-accent hover:text-black">
               Voir tout le catalogue
             </span>
                     </Link>

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -14,10 +14,10 @@ export default function Profile({ user }: { user: User | null }) {
 
     if (!user) {
         return (
-            <div className="w-full max-w-md bg-white rounded-2xl shadow-lg p-8 border text-center flex flex-col gap-5">
-                <h2 className="text-2xl font-bold mb-3">Bienvenue,</h2>
+            <div className="w-full max-w-md bg-white rounded-2xl shadow-lg p-8 border border-accent text-center flex flex-col gap-5">
+                <h2 className="text-2xl font-bold mb-3 text-accent">Bienvenue,</h2>
                 <div className="text-lg">Aucun utilisateur connecté.</div>
-                <Button className="w-full mt-8" asChild>
+                <Button className="w-full mt-8 bg-black text-white border border-accent hover:bg-accent hover:text-black" asChild>
                     <a href="/sign-in">Se connecter</a>
                 </Button>
             </div>
@@ -25,8 +25,8 @@ export default function Profile({ user }: { user: User | null }) {
     }
 
     return (
-        <div className="w-full max-w-md bg-white rounded-2xl shadow-lg p-8 border text-center flex flex-col gap-5">
-            <h2 className="text-2xl font-bold mb-3">Bienvenue,</h2>
+        <div className="w-full max-w-md bg-white rounded-2xl shadow-lg p-8 border border-accent text-center flex flex-col gap-5">
+            <h2 className="text-2xl font-bold mb-3 text-accent">Bienvenue,</h2>
             <div className="text-lg font-semibold">{user.email}</div>
             <Button className="w-full mt-8" variant="destructive" onClick={handleLogout}>
                 Se déconnecter

--- a/src/components/SignInForm.tsx
+++ b/src/components/SignInForm.tsx
@@ -32,7 +32,7 @@ export default function SignInForm() {
     return (
         <Card className="max-w-md w-full mx-auto shadow-2xl rounded-3xl border-0 bg-white/95">
             <CardHeader className="pt-10 pb-2 flex flex-col items-center gap-2">
-                <span className="text-3xl font-black tracking-tight uppercase text-black select-none">addlast</span>
+                <span className="text-3xl font-black tracking-tight uppercase text-accent select-none">addlast</span>
                 <CardTitle className="text-center text-2xl font-extrabold tracking-tight">Connexion</CardTitle>
             </CardHeader>
             <CardContent>
@@ -58,20 +58,20 @@ export default function SignInForm() {
                         <button
                             type="button"
                             onClick={() => setShowPassword(!showPassword)}
-                            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-black"
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-accent hover:text-accent-muted"
                         >
                             {showPassword ? <EyeOff size={18}/> : <Eye size={18}/>}
                         </button>
                     </div>
                     <div className="flex justify-between text-xs mb-1">
                         <span />
-                        <Link href="/forgot-password" className="text-gray-500 hover:text-black hover:underline transition">
+                        <Link href="/forgot-password" className="text-accent hover:text-accent-muted hover:underline transition">
                             Mot de passe oublié ?
                         </Link>
                     </div>
                     <Button
                         type="submit"
-                        className="w-full mt-2 rounded-full font-semibold transition hover:-translate-y-1 hover:shadow-xl"
+                        className="w-full mt-2 rounded-full font-semibold transition hover:-translate-y-1 hover:shadow-xl bg-black text-white border border-accent hover:bg-accent hover:text-black"
                         disabled={loading}
                     >
                         {loading ? "Connexion..." : "Se connecter"}
@@ -79,7 +79,7 @@ export default function SignInForm() {
                 </form>
                 <div className="text-sm mt-8 text-center">
                     Pas encore de compte ?{" "}
-                    <Link href="/sign-up" className="text-black underline font-semibold hover:no-underline hover:text-neutral-700 transition">
+                    <Link href="/sign-up" className="text-accent underline font-semibold hover:no-underline hover:text-accent-muted transition">
                         Créer un compte
                     </Link>
                 </div>

--- a/src/components/SignUpForm.tsx
+++ b/src/components/SignUpForm.tsx
@@ -75,7 +75,7 @@ export default function SignUpForm() {
     return (
         <Card className="max-w-md w-full mx-auto shadow-2xl rounded-3xl border-0 bg-white/95">
             <CardHeader className="pt-10 pb-2 flex flex-col items-center gap-2">
-                <span className="text-3xl font-black tracking-tight uppercase text-black select-none">
+                <span className="text-3xl font-black tracking-tight uppercase text-accent select-none">
                     addlast
                 </span>
                 <CardTitle className="text-center text-2xl font-extrabold tracking-tight">
@@ -136,7 +136,7 @@ export default function SignUpForm() {
                         <button
                             type="button"
                             onClick={() => setShowPassword(!showPassword)}
-                            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-black"
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-accent hover:text-accent-muted"
                         >
                             {showPassword ? <EyeOff size={18}/> : <Eye size={18}/>}
                         </button>
@@ -156,7 +156,7 @@ export default function SignUpForm() {
                         <button
                             type="button"
                             onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-black"
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-accent hover:text-accent-muted"
                         >
                             {showConfirmPassword ? <EyeOff size={18}/> : <Eye size={18}/>}
                         </button>
@@ -168,7 +168,7 @@ export default function SignUpForm() {
                             type="checkbox"
                             checked={newsletter}
                             onChange={(e) => setNewsletter(e.target.checked)}
-                            className="w-4 h-4 rounded transition focus:ring-2 focus:ring-black"
+                            className="w-4 h-4 rounded transition focus:ring-2 focus:ring-accent"
                         />
                         <label htmlFor="newsletter" className="text-sm">
                             Je souhaite recevoir la newsletter.
@@ -180,7 +180,7 @@ export default function SignUpForm() {
                             type="checkbox"
                             checked={acceptCgu}
                             onChange={(e) => setAcceptCgu(e.target.checked)}
-                            className="w-4 h-4 rounded transition focus:ring-2 focus:ring-black"
+                            className="w-4 h-4 rounded transition focus:ring-2 focus:ring-accent"
                             required
                         />
                         <label htmlFor="cgu" className="text-sm">
@@ -193,7 +193,7 @@ export default function SignUpForm() {
                     </div>
                     <Button
                         type="submit"
-                        className="w-full mt-2 rounded-full font-semibold transition hover:-translate-y-1 hover:shadow-xl"
+                        className="w-full mt-2 rounded-full font-semibold transition hover:-translate-y-1 hover:shadow-xl bg-black text-white border border-accent hover:bg-accent hover:text-black"
                         disabled={loading}
                     >
                         {loading ? "Création du compte..." : "S'inscrire"}
@@ -203,7 +203,7 @@ export default function SignUpForm() {
                     Déjà un compte ?{" "}
                     <Link
                         href="/sign-in"
-                        className="text-black underline font-semibold hover:no-underline hover:text-neutral-700 transition"
+                        className="text-accent underline font-semibold hover:no-underline hover:text-accent-muted transition"
                     >
                         Se connecter
                     </Link>

--- a/src/components/catalog-preview.tsx
+++ b/src/components/catalog-preview.tsx
@@ -29,7 +29,7 @@ export default function CatalogPreview({ products }: CatalogPreviewProps) {
                     {products.slice(0, 3).map((product) => (
                         <Card
                             key={product.id}
-                            className="group border border-black/20 hover:border-black transition-all duration-300 hover:shadow-lg bg-white"
+                            className="group border border-black/10 hover:border-accent transition-all duration-300 hover:shadow-lg bg-white"
                         >
                             <CardContent className="p-0">
                                 {/* Image */}
@@ -44,7 +44,7 @@ export default function CatalogPreview({ products }: CatalogPreviewProps) {
                                 {/* Contenu */}
                                 <div className="p-6 space-y-3">
                                     {/* Nom du modèle */}
-                                    <h3 className="text-lg font-medium text-black tracking-wide">{product.name}</h3>
+                                    <h3 className="text-lg font-medium text-black tracking-wide transition-colors group-hover:text-accent">{product.name}</h3>
 
                                     {/* Badge d'état */}
                                     <div className="flex justify-start">
@@ -53,7 +53,7 @@ export default function CatalogPreview({ products }: CatalogPreviewProps) {
                       inline-block px-3 py-1 text-xs font-medium tracking-wider uppercase
                       ${
                             product.status === "En vote"
-                                ? "bg-black text-white"
+                                ? "bg-black text-white border border-black"
                                 : product.status === "En précommande"
                                     ? "bg-white text-black border border-black"
                                     : "bg-gray-100 text-gray-600 border border-gray-300"
@@ -72,7 +72,7 @@ export default function CatalogPreview({ products }: CatalogPreviewProps) {
                 {/* CTA centré */}
                 <div className="text-center">
                     <Link href="/products">
-                        <Button className="bg-black text-white hover:bg-white hover:text-black border-2 border-black transition-all duration-300 px-8 py-3 text-base font-medium tracking-wide">
+                        <Button className="px-8 py-3 text-base font-medium tracking-wide">
                             Voir tout le catalogue
                         </Button>
                     </Link>

--- a/src/components/social-media-bento-grid.tsx
+++ b/src/components/social-media-bento-grid.tsx
@@ -75,14 +75,14 @@ export default function SocialMediaBentoGrid() {
         <section className="w-full max-w-6xl mx-auto px-4 py-12 bg-white">
             {/* Header Réseaux */}
             <div className="text-center mb-12">
-                <h2 className="text-3xl font-bold text-black mb-8">Nous suivre sur les réseaux</h2>
+                <h2 className="text-3xl font-bold text-accent mb-8">Nous suivre sur les réseaux</h2>
 
                 <div className="flex justify-center items-center gap-8 mb-12">
                     <Link href="https://www.tiktok.com/@add_last" target="_blank" className="text-center group">
                         <div className="w-16 h-16 bg-black rounded-2xl flex items-center justify-center mb-3 mx-auto transition hover:scale-110 hover:shadow-lg hover:bg-gray-800">
                             <TikTokIcon className="w-8 h-8 text-white" />
                         </div>
-                        <p className="text-sm font-medium text-black group-hover:text-gray-600">@add_last</p>
+                        <p className="text-sm font-medium text-accent group-hover:text-accent-muted">@add_last</p>
                         <p className="text-xs text-gray-600">TikTok</p>
                     </Link>
 
@@ -94,7 +94,7 @@ export default function SocialMediaBentoGrid() {
                         <div className="w-16 h-16 bg-black rounded-2xl flex items-center justify-center mb-3 mx-auto transition hover:scale-110 hover:shadow-lg hover:bg-gray-800">
                             <InstagramIcon className="w-8 h-8 text-white" />
                         </div>
-                        <p className="text-sm font-medium text-black group-hover:text-gray-600">@add_last</p>
+                        <p className="text-sm font-medium text-accent group-hover:text-accent-muted">@add_last</p>
                         <p className="text-xs text-gray-600">Instagram</p>
                     </Link>
 
@@ -102,7 +102,7 @@ export default function SocialMediaBentoGrid() {
                         <div className="w-16 h-16 bg-black rounded-2xl flex items-center justify-center mb-3 mx-auto transition hover:scale-110 hover:shadow-lg hover:bg-gray-800">
                             <YouTubeIcon className="w-8 h-8 text-white" />
                         </div>
-                        <p className="text-sm font-medium text-black group-hover:text-gray-600">@add-last</p>
+                        <p className="text-sm font-medium text-accent group-hover:text-accent-muted">@add-last</p>
                         <p className="text-xs text-gray-600">YouTube</p>
                     </Link>
                 </div>
@@ -116,7 +116,7 @@ export default function SocialMediaBentoGrid() {
                             <InstagramIcon className="w-6 h-6 text-white" />
                         </div>
                         <div className="text-left">
-                            <h3 className="text-xl font-bold text-black">@add_last</h3>
+                            <h3 className="text-xl font-bold text-accent">@add_last</h3>
                             <p className="text-sm text-gray-600">Dernières publications</p>
                         </div>
                     </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,16 +10,16 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+          "bg-black border border-black text-white shadow-xs hover:bg-accent hover:text-black hover:border-accent",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border border-black bg-background text-black shadow-xs hover:bg-accent hover:text-black hover:border-accent dark:bg-input/30 dark:border-input dark:text-white",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          "bg-black border border-black text-white shadow-xs hover:bg-accent hover:text-black hover:border-accent",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          "text-black hover:bg-accent hover:text-black dark:text-white dark:hover:text-black",
+        link: "text-black underline-offset-4 hover:text-accent hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "text-black transition-colors hover:text-[#7CFF6B] focus:bg-[#7CFF6B]/15 focus:text-[#7CFF6B] data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -92,7 +92,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "text-black transition-colors hover:text-[#7CFF6B] focus:bg-[#7CFF6B]/15 focus:text-[#7CFF6B] relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -128,7 +128,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "text-black transition-colors hover:text-[#7CFF6B] focus:bg-[#7CFF6B]/15 focus:text-[#7CFF6B] relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- update global utilities so links, text, and borders default to black and only flip to the green accent on hover
- restyle shared components (buttons, dropdown menus, catalog preview, wishlist, and CTA blocks) to adopt the black-first palette and green-hover accent
- align legal content pages with the new neutral heading/border treatment while preserving green as the hover colour for links

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd523bad7483219016c39e21640943